### PR TITLE
Fix failed requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ music
 config
 Music
 /docker-compose.yml
+dev*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+**v3.0.2 (22 Dec 2023)**
+- already downloaded log entries become info instead of warning
+- use `logger` instead of `logging`
+- `authorized_get_request` better handles different kinds of errors
+- all get requests use timeouts to prevent program hanging
+- remove `except Exception as e:`
+
+
 **v3.0.1 (22 Dec 2023)**
 - added logging support, replaced relevant prints with logger
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zyspotify"
-version = "3.0.1"
+version = "3.0.2"
 authors = [
     {"name" = "Jonathan Salinas Vargas"},
     {"name" = "Yuriy Kovrigin"},

--- a/zyspotify/__main__.py
+++ b/zyspotify/__main__.py
@@ -165,7 +165,7 @@ class ZYSpotify:
             if oserr.errno == errno.ENAMETOOLONG:
                 filename = filename[:GENERIC_MAX_STR_LEN]
 
-            else: # something unexpected
+            else:  # something unexpected
                 raise
 
         # TODO: there is more to flesh out here, filename still could be too long
@@ -560,12 +560,17 @@ class ZYSpotify:
             logger.info(f"ZYSpotify {__version__}")
             return
 
+        db_dir = Path(self.args.dbdir)
+        db_manager.create_db(db_dir)
+        logger.info(f"DB ready at {db_dir / 'zyspotify.db'}")
+
         try:
             logger.debug(
-                f"Public IP: {requests.get('https://api.ipify.org').content.decode('utf8')}"
+                f"Public IP: {requests.get('https://api.ipify.org', timeout=5).content.decode('utf8')}"
             )
         except requests.exceptions.RequestException:
             logger.error("IP check failed")
+
         self.splash()
         while not self.login():
             logger.error("Invalid credentials")

--- a/zyspotify/__main__.py
+++ b/zyspotify/__main__.py
@@ -223,7 +223,7 @@ class ZYSpotify:
                     db_manager.set_song_downloaded(
                         track_id, Path(song_path), should_commit=True
                     )
-                    logger.warning(f"Skipping {filename + ext} - Already downloaded")
+                    logger.info(f"Skipping {filename + ext} - Already downloaded")
                     return True
 
             output_path = self.respot.download(
@@ -253,7 +253,7 @@ class ZYSpotify:
             logger.info(f"Finished downloading {filename}")
 
         else:
-            logger.warning(f"Skipping song {track_id}, already downloaded")
+            logger.info(f"Skipping song {track_id}, already downloaded")
 
     def download_playlist(self, playlist_id):
         playlist = self.respot.request.get_playlist_info(playlist_id)
@@ -375,7 +375,7 @@ class ZYSpotify:
             db_manager.set_album_fully_downloaded(album_id, should_commit=True)
             logger.info(f"Finished downloading {album['artists']} - {album['name']} album")
         else:
-            logger.warning(f"Skipping album {album_id}, already fully downloaded")
+            logger.info(f"Skipping album {album_id}, already fully downloaded")
             return False
         return True
 
@@ -393,7 +393,7 @@ class ZYSpotify:
             db_manager.set_artist_fully_downloaded(artist_id, should_commit=True)
             logger.info(f"Finished downloading {artist_id} artist")
         else:
-            logger.warning(f"Skipping artist {artist_id}, already fully downloaded")
+            logger.info(f"Skipping artist {artist_id}, already fully downloaded")
         return True
 
     def download_all_songs_from_all_liked_artists(self):

--- a/zyspotify/__main__.py
+++ b/zyspotify/__main__.py
@@ -42,6 +42,7 @@ class ZYSpotify:
             force_premium=self.args.force_premium,
             audio_format=self.args.audio_format,
             antiban_wait_time=self.args.antiban_time,
+            force_liked_artist_query=self.args.force_liked_artist_query
         )
         self.search_limit = self.args.limit
 

--- a/zyspotify/arg_parser.py
+++ b/zyspotify/arg_parser.py
@@ -140,6 +140,13 @@ def parse_args():
         default=True,
     )
     parser.add_argument(
+        "-flaq",
+        "--force-liked-artist-query",
+        help="Force (ignore db check) querying all liked artists on account, useful when new artists have been added since first query.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-bd", "--bulk-download", help="Bulk download from file with urls"
     )
     parser.add_argument(

--- a/zyspotify/arg_parser.py
+++ b/zyspotify/arg_parser.py
@@ -81,6 +81,11 @@ def parse_args():
         default=Path.home() / "Music" / "ZYSpotify Music",
     )
     parser.add_argument(
+        "--dbdir",
+        help="Folder to save the database",
+        default=Path.home() / "zyspotify_config",
+    )
+    parser.add_argument(
         "-pd",
         "--episodes-dir",
         help="Folder to save the downloaded episodes files",

--- a/zyspotify/db.py
+++ b/zyspotify/db.py
@@ -197,8 +197,10 @@ class SQLiteDBManager:
     def store_all_liked_artists(
         self, packed_artists: list[PackedArtists], should_commit: bool = False
     ) -> None:
+        
+        # already inserted artists just ignore them
         self.cursor.executemany(
-            "INSERT INTO artists (artist_id, name) VALUES (?, ?)", packed_artists
+            "INSERT OR IGNORE INTO artists (artist_id, name) VALUES (?, ?)", packed_artists
         )
 
         if should_commit:

--- a/zyspotify/db.py
+++ b/zyspotify/db.py
@@ -95,9 +95,9 @@ CREATE TABLE IF NOT EXISTS credentials (
 
 class SQLiteDBManager:
     def __init__(self) -> None:
-        self.create_db()
+        ...
 
-    def create_db(self, db_dir: Path = Path.home() / "config"):
+    def create_db(self, db_dir: Path):
         Path.mkdir(db_dir, parents=True, exist_ok=True)
 
         self.connection = sqlite3.connect(

--- a/zyspotify/respot.py
+++ b/zyspotify/respot.py
@@ -31,12 +31,12 @@ API_ME = "https://api.spotify.com/v1/me/"
 
 
 class Respot:
-    def __init__(self, config_dir, force_premium, audio_format, antiban_wait_time):
+    def __init__(self, config_dir, force_premium, force_liked_artist_query, audio_format, antiban_wait_time):
         self.config_dir: Path = config_dir
         self.force_premium: bool = force_premium
         self.audio_format: str = audio_format
         self.antiban_wait_time: int = antiban_wait_time
-        self.auth: RespotAuth = RespotAuth(self.force_premium)
+        self.auth: RespotAuth = RespotAuth(self.force_premium, force_liked_artist_query)
         self.request: RespotRequest = None
 
     def is_authenticated(self, username=None, password=None) -> bool:
@@ -83,8 +83,9 @@ class Respot:
 
 
 class RespotAuth:
-    def __init__(self, force_premium):
+    def __init__(self, force_premium, force_liked_artist_query):
         self.force_premium = force_premium
+        self.force_liked_artist_query = force_liked_artist_query
         self.session = None
         self.token = None
         self.token_your_library = None
@@ -637,8 +638,8 @@ class RespotRequest:
             }
 
     def get_all_liked_artists(self) -> List[SpotifyArtistId]:
-        if not db_manager.have_all_liked_artists():
-            logger.info("need to request liked artists from spotify")
+        if not db_manager.have_all_liked_artists() or self.auth.force_liked_artist_query:
+            logger.info(f"{'[Forced] ' if self.auth.force_liked_artist_query else ''}need to request liked artists from spotify")
             all_liked_spotify_artists = self.request_all_liked_artists()
 
             # store in db

--- a/zyspotify/respot.py
+++ b/zyspotify/respot.py
@@ -66,17 +66,17 @@ class Respot:
         output_path = temp_path
 
         if extension == audio_bytes_format:
-            logging.info(f"Saving {output_path.stem} directly")
+            logger.info(f"Saving {output_path.stem} directly")
             handler.bytes_to_file(audio_bytes, output_path)
         elif extension == "source":
             output_str = filename + "." + audio_bytes_format
             output_path = temp_path.parent / output_str
-            logging.info(f"Saving {filename} as {extension}")
+            logger.info(f"Saving {filename} as {extension}")
             handler.bytes_to_file(audio_bytes, output_path)
         else:
             output_str = filename + "." + extension
             output_path = temp_path.parent / output_str
-            logging.info(f"Converting {filename} to {extension}")
+            logger.info(f"Converting {filename} to {extension}")
             handler.convert_audio_format(audio_bytes, output_path)
 
         return output_path
@@ -156,10 +156,10 @@ class RespotAuth:
         account_type = self.session.get_user_attribute("type")
         if account_type == "premium" or self.force_premium:
             self.quality = AudioQuality.VERY_HIGH
-            logging.info("[ DETECTED PREMIUM ACCOUNT - USING VERY_HIGH QUALITY ]\n")
+            logger.info("[ DETECTED PREMIUM ACCOUNT - USING VERY_HIGH QUALITY ]\n")
         else:
             self.quality = AudioQuality.HIGH
-            logging.info("[ DETECTED FREE ACCOUNT - USING HIGH QUALITY ]\n")
+            logger.info("[ DETECTED FREE ACCOUNT - USING HIGH QUALITY ]\n")
 
     def get_quality(self) -> AudioQuality:
         assert self.quality is not None
@@ -343,7 +343,7 @@ class RespotRequest:
         self, album_id: SpotifyAlbumId, artist_id: SpotifyArtistId
     ) -> list[PackedSongs]:
         if not db_manager.have_all_album_songs(album_id):
-            logging.info(f"need to request album {album_id}'s songs from spotify")
+            logger.info(f"need to request album {album_id}'s songs from spotify")
             songs = self.request_all_album_songs(album_id, artist_id)
 
             db_manager.store_album_songs(songs)
@@ -426,7 +426,7 @@ class RespotRequest:
 
     def get_artist_albums(self, artist_id) -> list[SpotifyAlbumId]:
         if not db_manager.have_all_artist_albums(artist_id):
-            logging.info(f"need to request artist {artist_id}'s albums from spotify")
+            logger.info(f"need to request artist {artist_id}'s albums from spotify")
             all_artist_albums = self.request_all_artist_albums(artist_id)
 
             db_manager.store_all_artist_albums(artist_id, all_artist_albums)
@@ -630,7 +630,7 @@ class RespotRequest:
 
     def get_all_liked_artists(self) -> List[SpotifyArtistId]:
         if not db_manager.have_all_liked_artists():
-            logging.info("need to request liked artists from spotify")
+            logger.info("need to request liked artists from spotify")
             all_liked_spotify_artists = self.request_all_liked_artists()
 
             # store in db
@@ -659,7 +659,7 @@ class RespotRequest:
                     name = str(song["track"]["artists"][0]["name"])
                     packed_artists.append((id, name))
             except KeyError:
-                logging.error(
+                logger.error(
                     f"Failed to get liked artists for offset: {offset}, continuing"
                 )
                 continue

--- a/zyspotify/tagger.py
+++ b/zyspotify/tagger.py
@@ -1,6 +1,23 @@
 import music_tag
 import requests
 from mutagen import id3
+import logging
+from time import sleep
+logger = logging.getLogger()
+
+
+def generic_get_request(url: str, retry_count: int = 0) -> requests.Response:
+    if retry_count > 10:
+        raise RuntimeError("ConnectionError: generic_get_request retries exceeded")
+
+    try:
+        return requests.get(url, timeout=5)
+    except requests.exceptions.RequestException as e:
+        logger.error(
+            f"generic_get_request RequestException: {'response had type none' if e.response is None else e.response.text}"
+        )
+        sleep(30)
+        return generic_get_request(url, retry_count+1)
 
 
 class AudioTagger:
@@ -86,7 +103,7 @@ class AudioTagger:
                 tags[tag] = id3.Frames[tag](encoding=3, text=value)
 
         if image_url:
-            albumart = requests.get(image_url, timeout=5).content
+            albumart = generic_get_request(image_url).content
             if albumart:
                 tags["APIC"] = id3.APIC(
                     encoding=3, mime="image/jpeg", type=3, desc="0", data=albumart
@@ -125,7 +142,7 @@ class AudioTagger:
                 tags[tag] = value
 
         if image_url:
-            albumart = requests.get(image_url, timeout=5).content
+            albumart = generic_get_request(image_url).content
             if albumart:
                 tags["artwork"] = albumart
 

--- a/zyspotify/tagger.py
+++ b/zyspotify/tagger.py
@@ -86,7 +86,7 @@ class AudioTagger:
                 tags[tag] = id3.Frames[tag](encoding=3, text=value)
 
         if image_url:
-            albumart = requests.get(image_url).content
+            albumart = requests.get(image_url, timeout=5).content
             if albumart:
                 tags["APIC"] = id3.APIC(
                     encoding=3, mime="image/jpeg", type=3, desc="0", data=albumart
@@ -125,7 +125,7 @@ class AudioTagger:
                 tags[tag] = value
 
         if image_url:
-            albumart = requests.get(image_url).content
+            albumart = requests.get(image_url, timeout=5).content
             if albumart:
                 tags["artwork"] = albumart
 


### PR DESCRIPTION
- already downloaded log entries become info instead of warning
- use `logger` instead of `logging`
- `authorized_get_request` better handles different kinds of errors
- all get requests use timeouts to prevent program hanging
- remove `except Exception as e:`
- add `--force-liked-artist-query` switch to rescan for new liked artists