### PR TITLE
add force album query switch to capture newly released albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docker CI](https://github.com/kaitallaoua/zyspotify/actions/workflows/docker-ci.yml/badge.svg)](https://github.com/kaitallaoua/zyspotify/actions/workflows/docker-ci.yml)
 [![GPLv3](https://img.shields.io/github/license/jsavargas/zspotify)](https://opensource.org/license/gpl-3-0)
 
-This is a work in progress, with active development. Expect breaking changes!
+This is a work in progress, with active development. Expect breaking changes! Expect that this program will eventually crash and need to be restarted. However with my changes it should resume where it left off very quickly! 
 
 This is a moderately modifed fork of ZSpotify with the goal of more robust large downloads (sqlite db instead of json archive file), eventually with the purpose to be run periodically/as a service to fetch new songs and more. A fork was decided as many, many changes were desired to be implemented more quickly than PR's.
 
@@ -56,11 +56,11 @@ Of course edit arguments as needed. To adjust music download dir, either
 Clone the repo, use virtual enviroments, pip install the requirements and follow the usage below
 
 ## Usage
-
+Note: not yet implmemented features/switches will raise a `NotImplementedError` and crash the program, as intended. This is not a bug!
 ```
-usage: __main__.py [-h] [-lsdall] [-ar ARTIST] [-cd CONFIG_DIR] [-ld LOG_DIR] [-md MUSIC_DIR] [--dbdir DBDIR] [-v] [-af {mp3,ogg,source}] [--album-in-filename] [--antiban-time ANTIBAN_TIME]
-                   [--antiban-album ANTIBAN_ALBUM] [--limit LIMIT] [-f] [-ns] [-flaq] [-mlsb MAX_LOG_SIZE_BYTES] [-lfl {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}]
-                   [-sll {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}]
+usage: __main__.py [-h] [-ap] [-sp] [-ls] [-lsdall] [-pl PLAYLIST] [-tr TRACK] [-al ALBUM] [-ar ARTIST] [-ep EPISODE] [-fs FULL_SHOW] [-cd CONFIG_DIR] [-ld LOG_DIR] [-md MUSIC_DIR] [--dbdir DBDIR]
+                   [-pd EPISODES_DIR] [-v] [-af {mp3,ogg,source}] [--album-in-filename] [--antiban-time ANTIBAN_TIME] [--antiban-album ANTIBAN_ALBUM] [--limit LIMIT] [-f] [-ns] [-flaq] [-faq]
+                   [-bd BULK_DOWNLOAD] [-mlsb MAX_LOG_SIZE_BYTES] [-lfl {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}] [-sll {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}]
                    [search]
 
 positional arguments:
@@ -68,10 +68,24 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  -ap, --all-playlists  Downloads all saved playlist from your library
+  -sp, --select-playlists
+                        Downloads a saved playlist from your library
+  -ls, --liked-songs    Downloads your liked songs
   -lsdall, --all-liked-all-artists
                         Download all songs from all (main) artists that appear in your liked songs
+  -pl PLAYLIST, --playlist PLAYLIST
+                        Download playlist by id or url
+  -tr TRACK, --track TRACK
+                        Downloads a track from their id or url
+  -al ALBUM, --album ALBUM
+                        Downloads an album from their id or url
   -ar ARTIST, --artist ARTIST
                         Downloads an artist from their id or url
+  -ep EPISODE, --episode EPISODE
+                        Downloads a episode from their id or url
+  -fs FULL_SHOW, --full-show FULL_SHOW
+                        Downloads all show episodes from id or url
   -cd CONFIG_DIR, --config-dir CONFIG_DIR
                         Folder to save the config files
   -ld LOG_DIR, --log-dir LOG_DIR
@@ -79,6 +93,8 @@ options:
   -md MUSIC_DIR, --music-dir MUSIC_DIR
                         Folder to save the downloaded music files
   --dbdir DBDIR         Folder to save the database
+  -pd EPISODES_DIR, --episodes-dir EPISODES_DIR
+                        Folder to save the downloaded episodes files
   -v, --version         Shows the current version of ZYSpotify and exit
   -af {mp3,ogg,source}, --audio-format {mp3,ogg,source}
                         Audio format to download the tracks. Use 'source' to preserve the source format without conversion.
@@ -93,6 +109,10 @@ options:
                         If flag setted NOT Skip existing already downloaded tracks
   -flaq, --force-liked-artist-query
                         Force (ignore db check) querying all liked artists on account, useful when new artists have been added since first query.
+  -faq, --force-album-query
+                        Force (ignore db check) query for albums for artists. Useful when artists release new songs since first query.
+  -bd BULK_DOWNLOAD, --bulk-download BULK_DOWNLOAD
+                        Bulk download from file with urls
   -mlsb MAX_LOG_SIZE_BYTES, --max-log-size-bytes MAX_LOG_SIZE_BYTES
                         Maximum size of log file in bytes.
   -lfl {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}, --log-file-level {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}

--- a/zyspotify/__main__.py
+++ b/zyspotify/__main__.py
@@ -42,7 +42,7 @@ class ZYSpotify:
             force_premium=self.args.force_premium,
             audio_format=self.args.audio_format,
             antiban_wait_time=self.args.antiban_time,
-            force_liked_artist_query=self.args.force_liked_artist_query
+            cli_args=self.args
         )
         self.search_limit = self.args.limit
 
@@ -413,10 +413,16 @@ class ZYSpotify:
         return True
 
     def download_artist(self, artist_id: SpotifyArtistId):
-        if not db_manager.have_artist_already_downloaded(artist_id):
+
+        if not db_manager.have_artist_already_downloaded(artist_id) or self.args.force_album_query:
+
+
 
             artist_name = self.respot.request.get_artist_info(artist_id)["name"]
 
+            if self.args.force_album_query:
+                logger.info(f"[Forced] fetching albums for artist {artist_name}")
+                
             # just attempt insert of artist, it may not exist already
             db_manager.store_artist((artist_id, artist_name), should_commit=True)
 

--- a/zyspotify/arg_parser.py
+++ b/zyspotify/arg_parser.py
@@ -140,6 +140,15 @@ def parse_args():
         action="store_true",
         default=False,
     )
+
+    parser.add_argument(
+        "-faq",
+        "--force-album-query",
+        help="Force (ignore db check) query for albums for artists. Useful when artists release new songs since first query.",
+        action="store_true",
+        default=False,
+    )
+
     parser.add_argument(
         "-bd", "--bulk-download", help="Bulk download from file with urls"
     )

--- a/zyspotify/respot.py
+++ b/zyspotify/respot.py
@@ -31,12 +31,12 @@ API_ME = "https://api.spotify.com/v1/me/"
 
 
 class Respot:
-    def __init__(self, config_dir, force_premium, force_liked_artist_query, audio_format, antiban_wait_time):
+    def __init__(self, config_dir, force_premium, cli_args, audio_format, antiban_wait_time):
         self.config_dir: Path = config_dir
         self.force_premium: bool = force_premium
         self.audio_format: str = audio_format
         self.antiban_wait_time: int = antiban_wait_time
-        self.auth: RespotAuth = RespotAuth(self.force_premium, force_liked_artist_query)
+        self.auth: RespotAuth = RespotAuth(self.force_premium, cli_args)
         self.request: RespotRequest = None
 
     def is_authenticated(self, username=None, password=None) -> bool:
@@ -83,9 +83,10 @@ class Respot:
 
 
 class RespotAuth:
-    def __init__(self, force_premium, force_liked_artist_query):
+    def __init__(self, force_premium, cli_args):
         self.force_premium = force_premium
-        self.force_liked_artist_query = force_liked_artist_query
+        self.force_liked_artist_query = cli_args.force_liked_artist_query
+        self.force_album_query = cli_args.force_album_query
         self.session = None
         self.token = None
         self.token_your_library = None
@@ -434,7 +435,7 @@ class RespotRequest:
             }
 
     def get_artist_albums(self, artist_id) -> list[SpotifyAlbumId]:
-        if not db_manager.have_all_artist_albums(artist_id):
+        if not db_manager.have_all_artist_albums(artist_id) or self.auth.force_album_query:
             logger.info(f"need to request artist {artist_id}'s albums from spotify")
             all_artist_albums = self.request_all_artist_albums(artist_id)
 


### PR DESCRIPTION
Add `-faq` switch, when combined with `-flaq`, is useful to fetch new artist albums in bypassing some caching that would otherwise by default ignore.